### PR TITLE
Reflect the Laravel 4.2 support in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Frenzy Turbolinks for Laravel 4.1.*
+Frenzy Turbolinks for Laravel 4.1.* and 4.2.*
 ==========
 
-Frenzy Turbolinks is a port of the rails [turbolinks](https://github.com/rails/turbolinks) gem and the [jquery.turbolinks](https://github.com/kossnocorp/jquery.turbolinks) gem for projects using the Laravel 4.1.*.
+Frenzy Turbolinks is a port of the rails [turbolinks](https://github.com/rails/turbolinks) gem and the [jquery.turbolinks](https://github.com/kossnocorp/jquery.turbolinks) gem for projects using the Laravel 4.1.* and 4.2.*.
 
 ## Versions
 


### PR DESCRIPTION
Just didn't see the 4.2 until I opened the composer.json file.