### PR TITLE
Support for PHP 8.0 and Laravel 6, 7 and 8 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0snapshot
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script: phpunit

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-Frenzy Turbolinks for Laravel 5.1+
+Frenzy Turbolinks for Laravel 6.0+
 ==================================
 
 Frenzy Turbolinks is a port of the Rails [turbolinks](https://github.com/turbolinks/turbolinks-rails) gem
-for projects using the PHP [Laravel](http://laravel.com) 5.1+ framework.
+for projects using the PHP [Laravel](http://laravel.com) 6.0+ framework.
 
 ## Versions
 
 Current versions of the following JavaScript libraries are used:
 
- * turbolinks: v5.0.0
+ * turbolinks: v5.2.0
+
+For [**Laravel 5.1 to 5.7**](http://laravel.com/docs/5.7) supports see [Frenzy Turbolinks `3.2.3` tag](https://github.com/frenzyapp/turbolinks/tree/3.2.3)
+
 
 For [**Laravel 5.0**](http://laravel.com/docs/5.0) supports see [Frenzy Turbolinks `3.0.0` tag](https://github.com/frenzyapp/turbolinks/tree/3.0.0)
 

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,15 @@
             "email": "tortuetorche@spam.me"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/tortuetorche/Turbolinks"
+        }
+    ],
     "require": {
-        "barryvdh/laravel-stack-middleware": "~1.2.1",
-        "helthe/turbolinks": "~2.2.0"
+        "barryvdh/laravel-stack-middleware": "~1.2.5",
+        "helthe/turbolinks": "dev-php8.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "frenzy/turbolinks",
-    "description": "Frenzy Turbolinks makes following links in your web application faster with Laravel 5",
+    "description": "Frenzy Turbolinks makes following links in your web application faster with Laravel",
     "keywords": [
-        "laravel", "laravel 5", "turbolinks", "turbolinks 5",
+        "laravel", "turbolinks",
         "javascript", "larasset", "assets", "ajax", "pjax"
     ],
     "license":     "MIT",

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,9 @@
             "email": "tortuetorche@spam.me"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/tortuetorche/Turbolinks"
-        }
-    ],
     "require": {
         "barryvdh/laravel-stack-middleware": "~1.2.5",
-        "helthe/turbolinks": "dev-php8.0"
+        "helthe/turbolinks": "^4.0.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
* Use `helthe/turbolinks` 4.0.0
* Drop PHP 5.5, 5.6, 7.0 and 7.1 support
* Drop Laravel 5.5, 5.6, 5.7 support

~~**Important:** Need some refactoring on `composer.json` file, but waiting for this pull request https://github.com/helthe/Turbolinks/pull/17 to be merged~~